### PR TITLE
Update read timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ COPY network_internal.conf /etc/nginx/
 
 RUN { \
       echo 'client_max_body_size 1024m;'; \
+      echo 'proxy_connect_timeout 10m;'; \
+      echo 'proxy_read_timeout 10m;'; \
     } > /etc/nginx/conf.d/catalyst.conf
 
 COPY . /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update \
  && apt-get clean \
  && rm -r /var/lib/apt/lists/*
 
+# Install nano
+RUN apt update \
+ && apt install nano
 
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \


### PR DESCRIPTION
## Notes
**Issue**: Client getting a 504 timeout when exporting plans. Timeout happens after a minute.

**Solution**: Update read and connect timeouts on nginx-proxy to 10 minutes.

## Changes
1. Update read and connect timeouts to 10 minutes in conf file.
2. Install nano when the dockerfile is run.

## QA
Test on US Recovery 3. Branch is already deployed there.  

QA already done on CN rails site by Seth.

Test API export on a client with large amount of plans. Example curl command is below (update the api token) 

curl -d "module=Plans&async=false" https://mckesson.bccatalyst.com/export/export.xls -H "Authorization: Token token=<your token>" > api_text.xls

Do a quick smoke test on portal and catalyst (just login to each). 

## Screenshots
BAD (export of data fails with 504)
![image](https://user-images.githubusercontent.com/43755993/78381814-e62c3f80-75a3-11ea-9b77-260d4409dbad.png)

GOOD (export works)
![image](https://user-images.githubusercontent.com/43755993/78381870-f9d7a600-75a3-11ea-9b04-de2e14c84c9e.png)

GOOD -- conf file is updated correctly
![image](https://user-images.githubusercontent.com/43755993/78381717-c4cb5380-75a3-11ea-8e66-b9439d57ca74.png)
