### PR TITLE
Increase buffer sizes to account for our now-larger header sizes

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -122,6 +122,8 @@ include /etc/nginx/proxy.conf;
 # HTTP 1.1 support
 proxy_http_version 1.1;
 proxy_buffering off;
+proxy_buffer_size 128k;
+proxy_buffers 4 256k;
 proxy_set_header Host $http_host;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection $proxy_connection;


### PR DESCRIPTION
This PR fixes an issue that consistently popped up on rec servers when our content security policies were added. The buffer size was not large enough to handle the full set of headers.